### PR TITLE
Add custom overrides for SmartyPants' default quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ The `smartypants` plugin comes with some sensible default configuration, that ar
 
 The options are described in detail on the [PHP SmartyPants GitHub Site](https://github.com/michelf/php-smartypants): https://github.com/michelf/php-smartypants
 
+You can override SmartyPants' default quotes (e.g. for other language styles like „German“):
+
+    dq_open:  &#8220;      // Custom HTML string for double quote open
+    dq_close: &#8221;      // Custom HTML string for double quote close
+    sq_open:  &#8216;      // Custom HTML string for single quote open
+    sq_close: &#8217;      // Custom HTML string for single quote close
+
 To customize the plugin, you first need to create an override config. To do so, create the folder `user/config/plugins` (if it doesn't exist already) and copy the [smartypants.yaml](smartypants.yaml) config file in there and then make your edits.
 
 Also you can override the default options per-page:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -79,3 +79,36 @@ form:
       size: large
       placeholder: "SmartyPants Options"
       help: See the docs for documentation: https://github.com/michelf/php-smartypants
+
+    overrides:
+      type: section
+      title: Overrides
+      underline: 1
+      fields:
+        dq_open:
+          type: text
+          label: Double quote open
+          size: small
+          placeholder: "&amp;#8220;"
+          help: Custom HTML string for double quote open
+
+        dq_close:
+          type: text
+          label: Double quote close
+          size: small
+          placeholder: "&amp;#8221;"
+          help: Custom HTML string for double quote close
+
+        sq_open:
+          type: text
+          label: Single quote open
+          size: small
+          placeholder: "&amp;#8216;"
+          help: Custom HTML string for single quote open
+
+        sq_close:
+          type: text
+          label: Single quote close / apostrophe
+          size: small
+          placeholder: "&amp;#8217;"
+          help: Custom HTML string for single quote close and apostrophe

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -83,7 +83,6 @@ form:
     overrides:
       type: section
       title: Overrides
-      underline: 1
       fields:
         dq_open:
           type: text

--- a/smartypants.php
+++ b/smartypants.php
@@ -35,6 +35,7 @@ class SmartypantsPlugin extends Plugin
         }
 
         require_once(__DIR__.'/vendor/Michelf/SmartyPants.php');
+        require_once(__DIR__.'/vendor/Michelf/SmartyPantsTypographer.php');
         $this->enable([
             'onTwigExtensions' => ['onTwigExtensions', 0],
             'onPageProcessed' => ['onPageProcessed', 0],
@@ -64,9 +65,9 @@ class SmartypantsPlugin extends Plugin
         $config = $this->mergeConfig($page);
 
         if ($config->get('process_title')) {
-            $page->title(\Michelf\SmartyPants::defaultTransform(
+            $page->title($this->transform(
                 $page->title(),
-                $config->get('options')
+                $config
             ));
         }
     }
@@ -80,9 +81,9 @@ class SmartypantsPlugin extends Plugin
         $config = $this->mergeConfig($page);
 
         if ($config->get('process_content')) {
-            $page->setRawContent(\Michelf\SmartyPants::defaultTransform(
+            $page->setRawContent($this->transform(
                 $page->getRawContent(),
-                $config->get('options')
+                $config
             ));
         }
     }
@@ -105,5 +106,21 @@ class SmartypantsPlugin extends Plugin
             $blueprint->extend($extends, true);
             $inEvent = false;
         }
+    }
+
+    /**
+     * Apply SmartyPants transformation on raw text.
+     *
+     * @param string $text raw text
+     * @return string transformed text
+     */
+    protected function transform($text, $config)
+    {
+        $smartypants = new \Michelf\SmartyPantsTypographer($config->get('options'));
+        if ($config->get('dq_open')) $smartypants->smart_doublequote_open = $config->get('dq_open');
+        if ($config->get('dq_close')) $smartypants->smart_doublequote_close = $config->get('dq_close');
+        if ($config->get('sq_open')) $smartypants->smart_singlequote_open = $config->get('sq_open');
+        if ($config->get('sq_close')) $smartypants->smart_singlequote_close = $config->get('sq_close');
+        return $smartypants->transform($text);
     }
 }

--- a/smartypants.php
+++ b/smartypants.php
@@ -111,8 +111,9 @@ class SmartypantsPlugin extends Plugin
     /**
      * Apply SmartyPants transformation on raw text.
      *
-     * @param string $text raw text
-     * @return string transformed text
+     * @param string $text Raw text
+     * @param object $config Configuration object
+     * @return string Transformed text
      */
     protected function transform($text, $config)
     {

--- a/twig/SmartyPantsTwigExtension.php
+++ b/twig/SmartyPantsTwigExtension.php
@@ -36,8 +36,18 @@ class SmartyPantsTwigExtension extends \Twig_Extension
         if (!$options) {
             $options = $this->config->get('plugins.smartypants.options');
         }
+        $smartypants = new \Michelf\SmartyPantsTypographer($options);
 
-        return \Michelf\SmartyPants::defaultTransform($content, $options);
+        if ($this->config->get('plugins.smartypants.dq_open'))
+            $smartypants->smart_doublequote_open = $this->config->get('plugins.smartypants.dq_open');
+        if ($this->config->get('plugins.smartypants.dq_close'))
+            $smartypants->smart_doublequote_close = $this->config->get('plugins.smartypants.dq_close');
+        if ($this->config->get('plugins.smartypants.sq_open'))
+            $smartypants->smart_singlequote_open = $this->config->get('plugins.smartypants.sq_open');
+        if ($this->config->get('plugins.smartypants.sq_close'))
+            $smartypants->smart_singlequote_close = $this->config->get('plugins.smartypants.sq_close');
+
+        return $smartypants->transform($content);
     }
 
 }


### PR DESCRIPTION
Many languages (like „German“) use [different quotation marks](https://en.wikipedia.org/wiki/Quotation_mark#Summary_table_for_all_languages).

In order to use those in Grav, I changed the SmartyPants plugin to use `SmartyPantsTypographer::transform` class instead of `SmartyPants::defaultTransform` and override the default quotation marks with the plugin options `dq_open`, `dq_close`, `sq_open` or `sq_close` if they are set.

I tested it with German quotation marks (`&#8222;`, `&#8218;`) for normal page content as well as using the Twig extension.

This approach works well for single-language sites.
For multi-language sites, language specific plugin configurations would be required.
