### PR TITLE
fix blueprint YAML formatting

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -78,7 +78,7 @@ form:
       label: Options
       size: large
       placeholder: "SmartyPants Options"
-      help: See the docs for documentation: https://github.com/michelf/php-smartypants
+      help: "See the docs for documentation: https://github.com/michelf/php-smartypants"
 
     overrides:
       type: section


### PR DESCRIPTION
I noticed this was filling up my Grav error logs:

```
Cannot load blueprint  /var/www/files/busseneau.fr/dev.nicolas/user/plugins/smartypants/blueprints.yaml:  Failed to read blueprints.yaml: A colon cannot be used in an unquoted  mapping value at line 81 (near "help: See the docs for documentation:  https://github.com/michelf/php-smartypants").
Blueprint smartypants/blueprints  cannot be loaded: Cannot load blueprint smartypants/blueprints: Failed  to read blueprints.yaml: A colon cannot be used in an unquoted mapping  value at line 81 (near "help: See the docs for documentation:  https://github.com/michelf/php-smartypants").
```

![2022-07-09_00-42-08_firefox](https://user-images.githubusercontent.com/4659919/178078994-99bf87cc-4166-4c88-8dc4-3704437f4d99.png)

Fortunately it's an easy fix :)